### PR TITLE
Fix problem empty cart(on ci3)

### DIFF
--- a/library_files/application/models/flexi_cart_lite_model.php
+++ b/library_files/application/models/flexi_cart_lite_model.php
@@ -51,7 +51,7 @@ class Flexi_cart_lite_model extends CI_Model
 		$this->flexi->error_messages = array('public' => array(), 'admin' => array());
 		
 		// Get current cart content from session.
-		if ($this->session->userdata($this->flexi->cart['name']) !== FALSE)
+		if ($this->session->userdata($this->flexi->cart['name']))
 		{
 			$this->flexi->cart_contents = $this->session->userdata($this->flexi->cart['name']);
 		}


### PR DESCRIPTION
Hi! on ci3 userdate return null not false, and cause  that validate the if and try to get data, makin a lot of bugs, but simply correct this, on ci3 works fine
